### PR TITLE
fix: split Avatar Dropdown context seperate interface,custom hooks fr…

### DIFF
--- a/src/components/ui/header/Avatar.tsx
+++ b/src/components/ui/header/Avatar.tsx
@@ -1,6 +1,6 @@
 import { FC, useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAvatarDropDownContext } from "../../../contexts/AvatarDropDownContext";
+import useAvatarDropDown from '../../../hooks/useAvatarDropDownContext';
 
 interface User {
   name: string;
@@ -26,7 +26,7 @@ const Avatar: FC = () => {
   // Toggle dropdown visibility
   const toggleDropdown = () => setIsDropdownOpen((prev) => !prev);
   const { setIsFeedBackClicked, setIsLogoutClicked } =
-    useAvatarDropDownContext();
+    useAvatarDropDown();
   // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/src/contexts/AvatarDropDownContext.tsx
+++ b/src/contexts/AvatarDropDownContext.tsx
@@ -1,24 +1,8 @@
-import { createContext, Dispatch, useContext } from "react";
-
-export interface IAvatarDropDown {
-  isLogOutClicked: boolean;
-  setIsLogoutClicked: Dispatch<React.SetStateAction<boolean>>;
-  isFeedBackClicked: boolean;
-  setIsFeedBackClicked: Dispatch<React.SetStateAction<boolean>>;
-}
+import { createContext} from "react";
+import { IAvatarDropDown } from "../interfaces/signup.interfaces";
 
 const AvatarDropDownContext = createContext<IAvatarDropDown | undefined>(
   undefined
 );
-
-export const useAvatarDropDownContext = (): IAvatarDropDown => {
-  const context = useContext(AvatarDropDownContext);
-  if (!context) {
-    throw new Error(
-      "useAvatarDropDownContext must be used within an AvatarProvider"
-    );
-  }
-  return context;
-};
 
 export default AvatarDropDownContext;

--- a/src/hooks/useAvatarDropDownContext.ts
+++ b/src/hooks/useAvatarDropDownContext.ts
@@ -1,0 +1,15 @@
+import { useContext } from "react";
+import { IAvatarDropDown } from "../interfaces/signup.interfaces";
+import AvatarDropDownContext from "../contexts/AvatarDropDownContext";
+
+const useAvatarDropDown = (): IAvatarDropDown => {
+  const context = useContext(AvatarDropDownContext);
+  if (!context) {
+    throw new Error(
+      "useAvatarDropDownContext must be used within an AvatarProvider"
+    );
+  }
+  return context;
+};
+
+export default useAvatarDropDown;

--- a/src/interfaces/signup.interfaces.ts
+++ b/src/interfaces/signup.interfaces.ts
@@ -1,5 +1,13 @@
-export interface ISignupPayload{
-    name:string,
-    email:string,
-    password:string
+import { Dispatch } from "react";
+export interface ISignupPayload {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export interface IAvatarDropDown {
+  isLogOutClicked: boolean;
+  setIsLogoutClicked: Dispatch<React.SetStateAction<boolean>>;
+  isFeedBackClicked: boolean;
+  setIsFeedBackClicked: Dispatch<React.SetStateAction<boolean>>;
 }

--- a/src/layouts/Main.tsx
+++ b/src/layouts/Main.tsx
@@ -3,9 +3,9 @@ import { Outlet, useLocation } from "react-router-dom";
 import Header from "../components/layout/Header";
 import Sidebar from "../components/layout/Sidebar";
 import CreateContactSmall from "../components/ui/CreateContactSmall";
-import { useAvatarDropDownContext } from "../contexts/AvatarDropDownContext";
 import LogoutModal from "../components/ui/LogoutModal";
 import FeedbackModal from "../components/ui/FeedbackModal";
+import useAvatarDropDown from "../hooks/useAvatarDropDownContext";
 
 const Main: FC = () => {
   const location = useLocation();
@@ -19,7 +19,7 @@ const Main: FC = () => {
     isLogOutClicked,
     setIsFeedBackClicked,
     setIsLogoutClicked,
-  } = useAvatarDropDownContext();
+  } = useAvatarDropDown();
   return (
     <>
       <Header />

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -68,9 +68,7 @@ const Signup: FC = () => {
   useEffect(() => {
     if (payload.password) {
       const password = payload.password;
-      password === confirmPassword
-        ? setIsPasswordMatched(true)
-        : setIsPasswordMatched(false);
+      setIsPasswordMatched(password === confirmPassword);
     } else {
       return;
     }


### PR DESCRIPTION
## 🛠️ Fix: Split Avatar Dropdown Context

### Summary

This PR refactors the `AvatarDropDownContext` by separating its concerns into multiple files to improve maintainability and align with React Fast Refresh best practices.

### Changes

- 🔁 **Moved** the `useAvatarDropDownContext` custom hook to its own file.
- 🧩 **Separated** the `IAvatarDropDown` interface into a dedicated types file.
- 💡 Ensured `AvatarDropDownContext.tsx` now only exports React components, preventing Fast Refresh warnings.

### Benefits

- ✅ Eliminates the `react-refresh/only-export-components` warning.
- ✅ Encourages modular, reusable, and clean code structure.
- ✅ Improves developer experience during development with proper hot reloading.

### Related

- ESLint rule: [`react-refresh/only-export-components`](https://github.com/reactwg/react-18/discussions/5)
