### PR TITLE
fix(image-upload): correct image upload endpoint in ImageApis to resolve upload failure

### DIFF
--- a/src/apis/image.apis.ts
+++ b/src/apis/image.apis.ts
@@ -2,14 +2,14 @@ import axiosClient from '../configs/axios.configs';
 
 const ImageApis = {
   imageUpload: (payload: FormData) => {
-    return axiosClient.post(`$/image`, payload, {
+    return axiosClient.post(`/image`, payload, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
     });
   },
   imageDelete: (payload: string) => {
-    return axiosClient.delete(`$/image/${payload}`);
+    return axiosClient.delete(`/image/${payload}`);
   },
 };
 


### PR DESCRIPTION
## Description

This pull request resolves a critical issue where users were unable to upload images when creating a contact. The problem was caused by an incorrect image upload endpoint in the `ImageApis` configuration. Specifically, the API was incorrectly using `$/image` instead of the correct `/image` path. This PR fixes the endpoint for both image upload and image delete operations.

## Type of Change

Please select the type of change that applies:

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update

## Checklist

- [x] I have tested the changes locally
- [ ] I have added/updated necessary documentation
- [x] I have reviewed the code for any errors

## Related Issue

This PR is not linked to any existing issue.

## Additional Notes

- The bug prevented image uploads during the contact creation flow.
- This was due to a typo in the endpoint string, using `$` instead of `/`.
- This is a blocking fix and should be merged as soon as possible to restore core functionality.
